### PR TITLE
Add accessibility semantics extensions and keys

### DIFF
--- a/example/lib/config/navigation/main_scaffold.dart
+++ b/example/lib/config/navigation/main_scaffold.dart
@@ -28,8 +28,16 @@ class MainScaffold extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Claryft', style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.white)),
-                Text('Components', style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white70)),
+                Text(
+                  key: key?.withSuffix('app_logo_text'),
+                  'Claryft',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.white),
+                ).withSemantics(),
+                Text(
+                  key: key?.withSuffix('app_logo_subtext'),
+                  'Components',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white70),
+                ).withSemantics(),
               ],
             ),
           ),
@@ -41,6 +49,7 @@ class MainScaffold extends StatelessWidget {
     );
 
     return Scaffold(
+      key: key?.withSuffix('main_scaffold'),
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       bottomNavigationBar:
           Responsive.isMobileSize()
@@ -68,7 +77,12 @@ class MainScaffold extends StatelessWidget {
               ? null
               : AppBar(
                 centerTitle: false,
-                title: Text(selectedRoute.name, style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black)),
+                title:
+                    Text(
+                      key: key?.withSuffix('app_bar_title'),
+                      selectedRoute.name,
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black),
+                    ).withSemantics(),
                 backgroundColor: Colors.white,
               ),
       drawer: isDesktop ? null : buildSidebar(),
@@ -84,10 +98,12 @@ class MainScaffold extends StatelessWidget {
                         if (isDesktop)
                           SliverAppBar(
                             pinned: true,
-                            title: Text(
-                              selectedRoute.name,
-                              style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black),
-                            ),
+                            title:
+                                Text(
+                                  key: key?.withSuffix('sliver_app_bar_title'),
+                                  selectedRoute.name,
+                                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black),
+                                ).withSemantics(),
                           ),
                         SliverToBoxAdapter(child: body),
                       ],
@@ -98,10 +114,12 @@ class MainScaffold extends StatelessWidget {
                         if (isDesktop)
                           AppBar(
                             centerTitle: false,
-                            title: Text(
-                              selectedRoute.name,
-                              style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black),
-                            ),
+                            title:
+                                Text(
+                                  key: key?.withSuffix('app_bar_title'),
+                                  selectedRoute.name,
+                                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: Colors.black),
+                                ).withSemantics(),
                           ),
                         Expanded(child: body),
                       ],
@@ -117,11 +135,24 @@ class MainScaffold extends StatelessWidget {
       margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
       decoration: BoxDecoration(borderRadius: BorderRadius.circular(8), color: isSelected ? AppColors.primaryColor : null),
       child: ListTile(
-        leading: Icon(item.icon, color: Colors.white),
-        title: Text(
-          item.title,
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: isSelected ? Colors.white : Colors.white70),
+        key: key?.withSuffix('menu_item_${item.title.toLowerCase()}'),
+        leading: Icon(key: key?.withSuffix('menu_item_icon'), item.icon, color: Colors.white).withSemantics(
+          label: item.title,
+          isButton: true,
+          onTap: () {
+            if (onMenuTap != null) {
+              onMenuTap!(item.route);
+            } else {
+              context.go(item.route);
+            }
+          },
         ),
+        title:
+            Text(
+              key: key?.withSuffix('menu_item_${item.title.toLowerCase()}'),
+              item.title,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: isSelected ? Colors.white : Colors.white70),
+            ).withSemantics(),
         onTap: () {
           if (onMenuTap != null) {
             onMenuTap!(item.route);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:claryft_components/claryft_components.dart';
 import 'package:example/config/router/routes.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  SemanticsBinding.instance.ensureSemantics();
   runApp(const MyApp());
 }
 

--- a/example/lib/modules/dashboard/pages/dashboard_page.dart
+++ b/example/lib/modules/dashboard/pages/dashboard_page.dart
@@ -10,6 +10,7 @@ class DashboardPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MainScaffold(
+      key: const ValueKey('dashboard_page'),
       selectedRoute: AppRoute.dashboard,
       onMenuTap: (route) {
         if (route != AppRoute.dashboard.path) {
@@ -22,30 +23,44 @@ class DashboardPage extends StatelessWidget {
           child: Column(
             children: [
               ElevatedButton(
+                key: const ValueKey('go_to_example_page_button'),
                 onPressed: () {},
                 child: Text(
                   'Go to Example Page',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(color: AppColors.whiteColor),
                 ),
-              ),
+              ).withButtonSemantics(),
               Gap(12),
-              OutlinedButton(onPressed: () {}, child: Text('Go to Example Page', style: Theme.of(context).textTheme.bodySmall)),
+              OutlinedButton(
+                key: const ValueKey('go_to_example_page_button'),
+                onPressed: () {},
+                child: Text('Go to Example Page', style: Theme.of(context).textTheme.bodySmall),
+              ).withButtonSemantics(),
               Gap(12),
-              TextField(decoration: InputDecoration(labelText: 'Enter text', hintText: 'Type something...')),
+              TextField(
+                key: const ValueKey('text_field'),
+                decoration: InputDecoration(labelText: 'Enter text', hintText: 'Type something...'),
+              ).withSemantics(),
               Gap(12),
               TextFormField(
+                key: const ValueKey('name_field'),
                 decoration: InputDecoration(
                   labelText: 'Enter your name',
                   hintText: 'John Doe',
 
                   border: OutlineInputBorder(borderRadius: BorderRadius.circular(14)),
                 ),
-              ),
+              ).withSemantics(),
               Gap(12),
               Card(
                 child: Padding(
                   padding: const EdgeInsets.all(16.0),
-                  child: Text('This is a card widget', style: Theme.of(context).textTheme.bodyMedium),
+                  child:
+                      Text(
+                        key: const ValueKey('card_text'),
+                        'This is a card widget',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ).withSemantics(),
                 ),
               ),
 
@@ -61,18 +76,22 @@ class DashboardPage extends StatelessWidget {
                               padding: const EdgeInsets.all(16.0),
                               height: 400,
                               child: Center(
-                                child: Text(
-                                  'This is a bottom sheet',
-                                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor),
-                                ),
+                                child:
+                                    Text(
+                                      key: const ValueKey('bottom_sheet_text'),
+                                      'This is a bottom sheet',
+                                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor),
+                                    ).withSemantics(),
                               ),
                             ),
                       );
                     },
-                    child: Text(
-                      'Click Me',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.primaryColor),
-                    ),
+                    child:
+                        Text(
+                          key: const ValueKey('show_bottom_sheet_button'),
+                          'Click Me',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.primaryColor),
+                        ).withSemantics(),
                   );
                 },
               ),
@@ -80,21 +99,53 @@ class DashboardPage extends StatelessWidget {
               Divider(color: AppColors.greyColor.withValues(alpha: 0.6), thickness: 1),
               Gap(12),
               ExpansionTile(
-                title: Text('Expansion Tile', style: Theme.of(context).textTheme.headlineSmall),
+                key: const ValueKey('expansion_tile'),
+                title:
+                    Text(
+                      key: const ValueKey('expansion_tile_title'),
+                      'Expansion Tile',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ).withSemantics(),
                 children: [
                   ListTile(
-                    title: Text('Item 1', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor)),
-                  ),
+                    key: const ValueKey('expansion_tile_item_1'),
+                    title:
+                        Text(
+                          key: const ValueKey('expansion_tile_item_1'),
+                          'Item 1',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor),
+                        ).withSemantics(),
+                  ).withSemantics(),
                   ListTile(
-                    title: Text('Item 2', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor)),
-                  ),
+                    key: const ValueKey('expansion_tile_item_2'),
+                    title:
+                        Text(
+                          key: const ValueKey('expansion_tile_item_2'),
+                          'Item 2',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor),
+                        ).withSemantics(),
+                  ).withSemantics(),
                   ListTile(
-                    title: Text('Item 3', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor)),
-                  ),
+                    key: const ValueKey('expansion_tile_item_3'),
+                    title:
+                        Text(
+                          'Item 3',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.blackColor),
+                        ).withSemantics(),
+                  ).withSemantics(),
                 ],
-              ),
+              ).withSemantics(),
               Gap(12),
-              Tooltip(message: 'This is a tooltip', child: Text('Hover over me', style: Theme.of(context).textTheme.bodyMedium)),
+              Tooltip(
+                key: const ValueKey('tooltip'),
+                message: 'This is a tooltip',
+                child:
+                    Text(
+                      key: const ValueKey('tooltip_text'),
+                      'Hover over me',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ).withSemantics(),
+              ).withSemantics(),
             ],
           ),
         ),

--- a/lib/claryft_components.dart
+++ b/lib/claryft_components.dart
@@ -49,3 +49,4 @@ export 'theme/custom_popup_menu_theme.dart';
 export 'theme/custom_dialog_theme.dart';
 export 'theme/custom_radio_theme.dart';
 export 'package:hugeicons/hugeicons.dart';
+export 'semantics_extensions.dart';

--- a/lib/semantics_extensions.dart
+++ b/lib/semantics_extensions.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+
+/// Extension on [Text] to add semantic labels and hints.
+extension TextSemanticsExt on Text {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [Icon] to improve accessibility.
+extension IconSemanticsExt on Icon {
+  Widget withSemantics({String? label, String? hint, bool isButton = false, VoidCallback? onTap}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, button: isButton, onTap: onTap, child: this);
+  }
+}
+
+/// Extension on [ElevatedButton], [TextButton], [OutlinedButton].
+extension ButtonSemanticsExt on Widget {
+  Widget withButtonSemantics({String? label, String? hint, VoidCallback? onTap}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: false, label: label, hint: hint, button: true, onTap: onTap, child: this);
+  }
+}
+
+/// Extension on [TextField] to describe form fields.
+extension TextFieldSemanticsExt on TextField {
+  Widget withSemantics({String? label, String? hint, bool readOnly = false}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, textField: true, readOnly: readOnly, child: this);
+  }
+}
+
+extension TextFormFieldSemanticsExt on TextFormField {
+  Widget withSemantics({String? label, String? hint, bool readOnly = false}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, textField: true, readOnly: readOnly, child: this);
+  }
+}
+
+/// Extension on [Checkbox].
+extension CheckboxSemanticsExt on Checkbox {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, checked: value, child: this);
+  }
+}
+
+/// Extension on [Radio].
+extension RadioSemanticsExt<T> on Radio<T> {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, checked: value == groupValue, child: this);
+  }
+}
+
+/// Extension on [Switch].
+extension SwitchSemanticsExt on Switch {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, toggled: value, child: this);
+  }
+}
+
+/// Extension on [Slider].
+extension SliderSemanticsExt on Slider {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, value: value.toString(), child: this);
+  }
+}
+
+/// Extension on [LinearProgressIndicator] / [CircularProgressIndicator].
+extension ProgressBarSemanticsExt on Widget {
+  Widget withProgressSemantics({String? label, String? hint, double? value}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, value: value?.toString(), child: this);
+  }
+}
+
+/// Extension on [Chip].
+extension ChipSemanticsExt on Chip {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label ?? this.label.toString(), hint: hint, child: this);
+  }
+}
+
+/// Extension on [Card].
+extension CardSemanticsExt on Card {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [ListTile].
+extension ListTileSemanticsExt on ListTile {
+  Widget withSemantics({String? label, String? hint, bool? selected}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(
+      identifier: id,
+      label: label ?? title.toString(),
+      hint: hint,
+      selected: selected ?? this.selected,
+      child: this,
+    );
+  }
+}
+
+/// Extension on [AppBar].
+extension AppBarSemanticsExt on AppBar {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [TabBar].
+extension TabBarSemanticsExt on TabBar {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [Drawer].
+extension DrawerSemanticsExt on Drawer {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [BottomNavigationBar].
+extension BottomNavigationBarSemanticsExt on BottomNavigationBar {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [FloatingActionButton].
+extension FloatingActionButtonSemanticsExt on FloatingActionButton {
+  Widget withSemantics({String? label, String? hint, VoidCallback? onTap}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, hint: hint, button: true, onTap: onTap ?? onPressed, child: this);
+  }
+}
+
+/// Extension on [Tooltip].
+extension TooltipSemanticsExt on Tooltip {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label ?? message, child: this);
+  }
+}
+
+/// Extension on [ExpansionTile].
+extension ExpansionTileSemanticsExt on ExpansionTile {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label ?? title.toString(), hint: hint, child: this);
+  }
+}
+
+/// Extension on [Dialog].
+extension DialogSemanticsExt on Dialog {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, namesRoute: true, label: label, child: this);
+  }
+}
+
+/// Extension on [SnackBar].
+extension SnackBarSemanticsExt on SnackBar {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, liveRegion: true, label: label ?? content.toString(), child: this);
+  }
+}
+
+/// Extension on [PopupMenuButton].
+extension PopupMenuSemanticsExt<T> on PopupMenuButton<T> {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, button: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [Image].
+extension ImageSemanticsExt on Image {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, image: true, label: label, child: this);
+  }
+}
+
+/// Extension on [Divider].
+extension DividerSemanticsExt on Divider {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, label: label, child: this);
+  }
+}
+
+/// Extension on [Container].
+extension ContainerSemanticsExt on Container {
+  Widget withSemantics({String? label, String? hint}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, hint: hint, child: this);
+  }
+}
+
+/// Extension on [Row].
+extension RowSemanticsExt on Row {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, child: this);
+  }
+}
+
+/// Extension on [Column].
+extension ColumnSemanticsExt on Column {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, child: this);
+  }
+}
+
+/// Extension on [Stack].
+extension StackSemanticsExt on Stack {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, label: label, child: this);
+  }
+}
+
+/// Extension on [Scaffold].
+extension ScaffoldSemanticsExt on Scaffold {
+  Widget withSemantics({String? label}) {
+    String id = label ?? ((key is ValueKey) ? (key as ValueKey).value.toString() : runtimeType.toString());
+    return Semantics(identifier: id, container: true, namesRoute: true, label: label, child: this);
+  }
+}
+
+extension KeyExtension on Key? {
+  ValueKey withSuffix(String suffix) {
+    final String originalKey = (this as ValueKey).value.toString();
+    return ValueKey('${originalKey}_$suffix');
+  }
+
+  String get keyToString => (this as ValueKey).value.toString();
+}


### PR DESCRIPTION
Introduces `semantics_extensions.dart` with widget extensions for improved accessibility and semantic labeling. Updates example app to use these extensions and adds ValueKeys to widgets for better testability and accessibility. Also ensures semantics are initialized in main.dart and exports the new extensions in the main library.